### PR TITLE
Increment the jpo-deduplicator version

### DIFF
--- a/.github/workflows/artifact-publish.yml
+++ b/.github/workflows/artifact-publish.yml
@@ -1,12 +1,8 @@
 name: Publish Java Package
 
 on:
-  push:
-    branches:
-      - "develop"
-      - "master"
-      - "release/*"
-    
+  release:
+    types: [published]
 
 jobs:
   deduplicator-publish:

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   dockerhub-jpo-deduplicator:
+    if: github.event.pull_request.base.repo.owner.login == 'usdot-jpo-ode'
     uses: usdot-jpo-ode/actions/.github/workflows/dockerhub.yml@main
     with:
       image: usdotjpoode/jpo-deduplicator

--- a/jpo-deduplicator/pom.xml
+++ b/jpo-deduplicator/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-deduplicator</artifactId>
-    <version>2.2.0</version>
+    <version>3.0.0</version>
     <packaging>jar</packaging>
     <name>jpo-deduplicator</name>
     <url>http://maven.apache.org</url>

--- a/jpo-deduplicator/pom.xml
+++ b/jpo-deduplicator/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-deduplicator</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <packaging>jar</packaging>
     <name>jpo-deduplicator</name>
     <url>http://maven.apache.org</url>


### PR DESCRIPTION
Increments the jpo-deduplicator version to 3.0.0 after the recent updates that introduce breaking changes by supporting the new major version for the jpo-ode and jpo-geojsonconverter.