### PR TITLE
Hash ode map json deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ The processes that determine which messages are duplicates are unique and custom
 ### OdeMapJson
 - Two messages within a 1 hour time window 
 - Two messages have the same intersection ID
+- The Messages have the same hash values after remove the `ASN1`, `OdeReceivedAt` and  `MOY` fields
 
 ### ProcessedMap and ProcessedMapWKT
 - Two messages within a 1 hour time window
-- Two messages have the same hash values after factoring out the odeReceivedAt and timeStamp fields
+- Two messages have the same hash values after factoring out the `ASN1`, `odeReceivedAt` and `timeStamp` fields
 
 ### OdeTimJson
 - Two messages within a 1 hour time window

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The processes that determine which messages are duplicates are unique and custom
 
 ### ProcessedMap and ProcessedMapWKT
 - Two messages within a 1 hour time window
-- Two messages have the same hash values after factoring out the `ASN1`, `odeReceivedAt` and `timeStamp` fields
+- Two messages are the same after factoring out the `ASN1`, `odeReceivedAt` and `timeStamp` fields
 
 ### OdeTimJson
 - Two messages within a 1 hour time window

--- a/jpo-deduplicator/pom.xml
+++ b/jpo-deduplicator/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-deduplicator</artifactId>
-    <version>3.0.1</version>
+    <version>3.1.0</version>
     <packaging>jar</packaging>
     <name>jpo-deduplicator</name>
     <url>http://maven.apache.org</url>

--- a/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/processors/OdeMapJsonProcessor.java
+++ b/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/processors/OdeMapJsonProcessor.java
@@ -43,7 +43,7 @@ public class OdeMapJsonProcessor extends DeduplicationProcessor<OdeMessageFrameD
             boolean lastMessageIsNull = (lastMessage == null || lastMessage.getPayload() == null || lastMessage.getPayload().getData() == null);
             boolean newMessageIsNull = (newMessage == null || newMessage.getPayload() == null || newMessage.getPayload().getData() == null);
             if ((lastMessageIsNull && !newMessageIsNull) || (!lastMessageIsNull && newMessageIsNull)) {
-                logger.warn("One TIM message has a null payload or data, treating as non-duplicate");
+                logger.warn("One MAP message has a null payload or data, treating as non-duplicate");
                 return true;
             }
 

--- a/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/processors/OdeMapJsonProcessor.java
+++ b/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/processors/OdeMapJsonProcessor.java
@@ -44,7 +44,7 @@ public class OdeMapJsonProcessor extends DeduplicationProcessor<OdeMessageFrameD
             boolean newMessageIsNull = (newMessage == null || newMessage.getPayload() == null || newMessage.getPayload().getData() == null);
             if ((lastMessageIsNull && !newMessageIsNull) || (!lastMessageIsNull && newMessageIsNull)) {
                 logger.warn("One MAP message has a null payload or data, treating as non-duplicate");
-                return true;
+                return false;
             }
 
             // Hash both messages and see if they match

--- a/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/processors/OdeMapJsonProcessor.java
+++ b/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/processors/OdeMapJsonProcessor.java
@@ -2,10 +2,12 @@ package us.dot.its.jpo.deduplicator.deduplicator.processors;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import us.dot.its.jpo.asn.j2735.r2024.MapData.MapDataMessageFrame;
 import us.dot.its.jpo.deduplicator.DeduplicatorProperties;
 import us.dot.its.jpo.deduplicator.utils.OdeJsonUtils;
 import us.dot.its.jpo.ode.model.OdeMessageFrameData;
@@ -44,11 +46,40 @@ public class OdeMapJsonProcessor extends DeduplicationProcessor<OdeMessageFrameD
                 logger.warn("One TIM message has a null payload or data, treating as non-duplicate");
                 return true;
             }
+
+            // Hash both messages and see if they match
+            MapDataMessageFrame oldMapMessageFrame = (MapDataMessageFrame) lastMessage.getPayload().getData();
+            MapDataMessageFrame newMapMessageFrame = (MapDataMessageFrame) newMessage.getPayload().getData();
+
+            long oldMapMoy = oldMapMessageFrame.getValue().getTimeStamp().getValue();
+            long newMapMoy = newMapMessageFrame.getValue().getTimeStamp().getValue();
+
+            String oldMapAsn1 = lastMessage.getMetadata().getAsn1();
+            String newMapAsn1 = newMessage.getMetadata().getAsn1();
+
+            String oldMapOdeReceivedAt = lastMessage.getMetadata().getOdeReceivedAt();
+            String newMapOdeReceivedAt = newMessage.getMetadata().getOdeReceivedAt();
+
+            // Temporarily copy certain fields which are expected to differ between non-perfect duplicates
+            newMapMessageFrame.getValue().getTimeStamp().setValue(oldMapMoy);
+            newMessage.getMetadata().setAsn1(oldMapAsn1);
+            newMessage.getMetadata().setOdeReceivedAt(oldMapOdeReceivedAt);
+
+            int oldHash = Objects.hash(lastMessage.toString());
+            int newHash = Objects.hash(newMessage.toString());
+
+            if(oldHash != newHash){
+                newMapMessageFrame.getValue().getTimeStamp().setValue(newMapMoy);
+                newMessage.getMetadata().setAsn1(newMapAsn1);
+                newMessage.getMetadata().setOdeReceivedAt(newMapOdeReceivedAt);
+                return false;
+            }
+
         } catch (Exception e) {
             logger.warn("Caught General Exception while checking Map duplicates: " + e.getMessage(), e);
         }
 
-        // Treat maps as duplicates if they have the same intersection ID and
+        // Treat maps as duplicates if they are identical other than timestamps and within one hour of each other
         // are within the 1 hour time window
         return true;
     }

--- a/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/processors/OdeMapJsonProcessor.java
+++ b/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/processors/OdeMapJsonProcessor.java
@@ -65,10 +65,7 @@ public class OdeMapJsonProcessor extends DeduplicationProcessor<OdeMessageFrameD
             newMessage.getMetadata().setAsn1(oldMapAsn1);
             newMessage.getMetadata().setOdeReceivedAt(oldMapOdeReceivedAt);
 
-            int oldHash = Objects.hash(lastMessage.toString());
-            int newHash = Objects.hash(newMessage.toString());
-
-            if(oldHash != newHash){
+            if(!lastMessage.toString().equals(newMessage.toString())){
                 newMapMessageFrame.getValue().getTimeStamp().setValue(newMapMoy);
                 newMessage.getMetadata().setAsn1(newMapAsn1);
                 newMessage.getMetadata().setOdeReceivedAt(newMapOdeReceivedAt);

--- a/jpo-deduplicator/src/test/java/us/dot/its/jpo/deduplicator/deduplicator/MapDeduplicatorTopologyTest.java
+++ b/jpo-deduplicator/src/test/java/us/dot/its/jpo/deduplicator/deduplicator/MapDeduplicatorTopologyTest.java
@@ -167,7 +167,7 @@ public class MapDeduplicatorTopologyTest {
             List<KeyValue<String, OdeMessageFrameData>> mapDeduplicationResults = outputOdeMapData
                     .readKeyValuesToList();
 
-            // validate that only 3 messages make it through
+            // validate that only 4 messages make it through
             assertEquals(4, mapDeduplicationResults.size());
 
             OdeMessageFrameData map1 = objectMapper.readValue(inputMap1, OdeMessageFrameData.class);

--- a/jpo-deduplicator/src/test/java/us/dot/its/jpo/deduplicator/deduplicator/MapDeduplicatorTopologyTest.java
+++ b/jpo-deduplicator/src/test/java/us/dot/its/jpo/deduplicator/deduplicator/MapDeduplicatorTopologyTest.java
@@ -45,6 +45,7 @@ public class MapDeduplicatorTopologyTest {
     String inputMap3 = "";
     String inputMap4 = "";
     String inputMap5 = "";
+    String inputMap6 = "";
 
     @Autowired
     DeduplicatorProperties props;
@@ -71,6 +72,7 @@ public class MapDeduplicatorTopologyTest {
         Instant instant = Instant.parse(originalTime);
         Instant newInstant = instant.plus(5, ChronoUnit.MINUTES);
         map5MinutesLater.getMetadata().setOdeReceivedAt(newInstant.toString());
+
         // ASN1 modified to show that this message is a deduplicated irrelevant to it
         map5MinutesLater.getMetadata().setAsn1(map5MinutesLater.getMetadata().getAsn1() + "1");
 
@@ -91,14 +93,31 @@ public class MapDeduplicatorTopologyTest {
                 OdeMessageFrameData.class);
         originalTime = map1HourLater.getMetadata().getOdeReceivedAt();
         instant = Instant.parse(originalTime);
-        newInstant = instant.plus(61, ChronoUnit.HOURS);
+        newInstant = instant.plus(61, ChronoUnit.MINUTES);
         map1HourLater.getMetadata().setOdeReceivedAt(newInstant.toString());
 
         mf = (MapDataMessageFrame) map1HourLater.getPayload().getData();
-        newMoy = new MinuteOfTheYear(mf.getValue().getTimeStamp().getValue() + 60);
+        newMoy = new MinuteOfTheYear(mf.getValue().getTimeStamp().getValue() + 61);
         mf.getValue().setTimeStamp(newMoy);
         map1HourLater.getPayload().setData(mf);
         inputMap5 = map1HourLater.toJson();
+
+        // Message 5 with a slightly different lane geometry. Should be kept as non-duplicate. (Uses same timestamp as message above so that it is not automatically forwarded due to time difference)
+        OdeMessageFrameData mapWithDifferentLaneGeometry = objectMapper.readValue(mapReferenceData.toJson(),
+                OdeMessageFrameData.class);
+        originalTime = mapWithDifferentLaneGeometry.getMetadata().getOdeReceivedAt();
+        instant = Instant.parse(originalTime);
+        newInstant = instant.plus(61, ChronoUnit.MINUTES);
+        mapWithDifferentLaneGeometry.getMetadata().setOdeReceivedAt(newInstant.toString());
+
+        mf = (MapDataMessageFrame) mapWithDifferentLaneGeometry.getPayload().getData();
+        mf.getValue().getIntersections().get(0).getLaneSet().get(0).getLaneID().setValue(42); // Set a different lane ID to make the geometry different
+
+        newMoy = new MinuteOfTheYear(mf.getValue().getTimeStamp().getValue() + 61);
+        mf.getValue().setTimeStamp(newMoy);
+        mapWithDifferentLaneGeometry.getPayload().setData(mf);
+        inputMap6 = mapWithDifferentLaneGeometry.toJson();
+        
     }
 
     @Test
@@ -143,20 +162,23 @@ public class MapDeduplicatorTopologyTest {
             inputOdeMapData.pipeInput(null, inputMap3);
             inputOdeMapData.pipeInput(null, inputMap4);
             inputOdeMapData.pipeInput(null, inputMap5);
+            inputOdeMapData.pipeInput(null, inputMap6);
 
             List<KeyValue<String, OdeMessageFrameData>> mapDeduplicationResults = outputOdeMapData
                     .readKeyValuesToList();
 
             // validate that only 3 messages make it through
-            assertEquals(3, mapDeduplicationResults.size());
+            assertEquals(4, mapDeduplicationResults.size());
 
             OdeMessageFrameData map1 = objectMapper.readValue(inputMap1, OdeMessageFrameData.class);
             OdeMessageFrameData map4 = objectMapper.readValue(inputMap4, OdeMessageFrameData.class);
             OdeMessageFrameData map5 = objectMapper.readValue(inputMap5, OdeMessageFrameData.class);
+            OdeMessageFrameData map6 = objectMapper.readValue(inputMap6, OdeMessageFrameData.class);
 
             assertThat(mapDeduplicationResults.get(0).value.toJson(), jsonEquals(map1.toJson()));
             assertThat(mapDeduplicationResults.get(1).value.toJson(), jsonEquals(map4.toJson()));
             assertThat(mapDeduplicationResults.get(2).value.toJson(), jsonEquals(map5.toJson()));
+            assertThat(mapDeduplicationResults.get(3).value.toJson(), jsonEquals(map6.toJson()));
 
         } catch (JsonMappingException e) {
             e.printStackTrace();


### PR DESCRIPTION
This PR updates the logic in the OdeMapJson deduplication topology so that it will forward a new MAP message if the new map message is different from the previous message. Previously, a new OdeMapJson message would only be forwarded if it happens more than 1 hour after the preceeding message. After this update, a new OdeMapJson message will also be forwarded if it has different contents than the previous MAP message. For example, if the new message has different lane ID's or geometries it will be forwarded regardless of how long after the previous message the new message occurred. This update changes the OdeMapJson topology logic to be more in line with how the ProcessedMap and other topologies operate. As with the ProcessedMap topology, this update ignores changes to the ASN.1, odeReceivedAt, and MOY fields since these fields are expected to change frequently and do not necessarily correspond to a change in the intersection geometry. 